### PR TITLE
Fixed a Typo in subdomainer.sh

### DIFF
--- a/subdomainer.sh
+++ b/subdomainer.sh
@@ -392,7 +392,7 @@ amsIgnore() {
 
 "
 
-   amass enum -passive -norecursive -noalts -d "$domains -o result/$date/$domains-amass-enum.txt"
+   amass enum -passive -norecursive -noalts -d $domains -o "result/$date/$domains-amass-enum.txt"
 
    printf "
 


### PR DESCRIPTION
## Changed Line Number 395
from this:  
>amass enum -passive -norecursive -noalts -d "$domains -o result/$date/$domains-amass-enum.txt"  

to this: 
>amass enum -passive -norecursive -noalts -d $domains -o "result/$date/$domains-amass-enum.txt"

😀👍